### PR TITLE
Fix 'src' in bluesky-profile-card example should actually be 'actor'

### DIFF
--- a/packages/bluesky-profile-card-embed/README.md
+++ b/packages/bluesky-profile-card-embed/README.md
@@ -22,7 +22,7 @@ import 'bluesky-profile-card-embed/themes/light.css';
 ## Usage
 
 ```html
-<bluesky-profile-card src="did:plc:2gkh62xvzokhlf6li4ol3b3d">
+<bluesky-profile-card actor="did:plc:2gkh62xvzokhlf6li4ol3b3d">
 	<a
 		target="_blank"
 		href="https://bsky.app/profile/did:plc:2gkh62xvzokhlf6li4ol3b3d"


### PR DESCRIPTION
Otherwise it just tries to fetch `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=null`. See:

https://github.com/mary-ext/bluesky-embed/blob/25687f4eb98885b1d0cd623391759d19b1792d7e/packages/bluesky-profile-card-embed/src/app.tsx#L50-L52