### PR TITLE
feat: add error handling to web components

### DIFF
--- a/packages/bluesky-post-embed/lib/wc.ts
+++ b/packages/bluesky-post-embed/lib/wc.ts
@@ -1,4 +1,4 @@
-import { fetchPost, renderPost } from './core';
+import { fetchPost, type PostData, renderPost } from './core';
 
 export class BlueskyPost extends HTMLElement {
 	connectedCallback() {
@@ -19,7 +19,15 @@ export class BlueskyPost extends HTMLElement {
 		const contextless = this.getAttribute('contextless') !== null;
 		const allowUnauthenticated = this.getAttribute('allow-unauthenticated') !== null;
 
-		const data = await fetchPost({ uri: src, contextless, allowUnauthenticated, serviceUri });
+		let data: PostData;
+		try {
+			data = await fetchPost({ uri: src, contextless, allowUnauthenticated, serviceUri });
+		} catch (error) {
+			console.warn('Failed to fetch post:', error);
+			// Leave the fallback content in place
+			return;
+		}
+
 		const html = renderPost(data);
 
 		const root = this.shadowRoot;

--- a/packages/bluesky-profile-card-embed/lib/wc.ts
+++ b/packages/bluesky-profile-card-embed/lib/wc.ts
@@ -18,7 +18,15 @@ export class BlueskyProfileCard extends HTMLElement {
 		const serviceUri = this.getAttribute('service-uri') || undefined;
 		const allowUnauthenticated = this.getAttribute('allow-unauthenticated') !== null;
 
-		const data = await fetchProfileCard({ actor, allowUnauthenticated, serviceUri });
+		let data;
+		try {
+			data = await fetchProfileCard({ actor, allowUnauthenticated, serviceUri });
+		} catch (error) {
+			console.warn('Failed to fetch profile card:', error);
+			// Leave the fallback content in place
+			return;
+		}
+
 		const html = renderProfileCard(data);
 
 		const root = this.shadowRoot;


### PR DESCRIPTION
This PR adds error handling to the web components ( and ) by wrapping the fetch calls in try-catch blocks. This ensures that if fetching fails, the components gracefully handle the error and preserve any fallback content that may be present.

(very LLMy but it does work)

This avoids reporting NetworkErrors to Sentry (in Buttondown) and cleanly falls back to the fallback content.